### PR TITLE
build: harden Dockerfiles + 2026 BuildKit best practices + Tomcat CVE fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Keep .git in the build context — git-commit-id-plugin reads HEAD/commit metadata
+# during `mvn package` to generate src/main/resources/.../git.properties. Everything
+# else below trims the BuildKit context to speed up every build by a few seconds and
+# avoids leaking local artefacts into the build stage.
+
+# Build artefacts — the main Dockerfile runs `mvn package` inside the build stage.
+# Dockerfile.maven-host-m2-cache has its own `COPY target target` so target/ is
+# NOT added here; add it back if this file ever serves both Dockerfiles exclusively.
+
+# IDE / editor state
+.idea/
+.vscode/
+*.iml
+*.iws
+*.ipr
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Runtime artefacts (would be recreated inside the container anyway)
+*.log
+*.log.*
+application.log
+
+# Misc project files not needed by docker build
+README.md
+CLAUDE.md
+LICENSE
+.gitignore
+.claudeignore
+.claude/
+docs/
+img/
+skaffold.yaml
+.travis.yml
+renovate.json
+.java-version
+.mise.toml
+
+# Scripts — build-time context only needs pom.xml + src + .git
+scripts/
+
+# CI / GitHub — not needed inside the image
+.github/
+
+# Maven wrapper (we use system/mise maven in the build stage)
+mvnw
+mvnw.cmd
+.mvn/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # renovate: datasource=docker depName=maven
 ARG MAVEN_IMAGE_VERSION=3.9.15-eclipse-temurin-25
 
@@ -6,40 +8,41 @@ ARG TEMURIN_IMAGE_VERSION=25.0.2_10-jre-jammy@sha256:d36843a6f1af5d0aca01ef3d926
 
 FROM maven:${MAVEN_IMAGE_VERSION} AS build
 WORKDIR /build
+
+# Dependency layer — BuildKit cache mount persists ~/.m2 across builds.
+# Invalidates only when pom.xml changes.
 COPY pom.xml .
-COPY .git .
-RUN mvn dependency:go-offline
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B dependency:go-offline
 
-COPY ./pom.xml /tmp/
-COPY ./src /tmp/src/
-COPY ./.git /tmp/.git/
+# Source + git metadata — git-commit-id-plugin needs .git for git.properties.
+COPY src src
+COPY .git .git
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B package
 
-WORKDIR /tmp/
-RUN mvn clean package
-
-# extract JAR Layers
-WORKDIR /tmp/target
-RUN java -Djarmode=layertools -jar *.jar extract
+# Extract Spring Boot layered jar
+WORKDIR /build/target
+RUN java -Djarmode=layertools -jar ./*.jar extract
 
 FROM eclipse-temurin:${TEMURIN_IMAGE_VERSION} AS runtime
 
-# Eclipse Temurin 25 LTS (Ubuntu Jammy) — actively CVE-patched upstream.
-# Create a non-root user with a numeric UID so Kubernetes can verify
-# `runAsNonRoot: true` at admission time.
+# Non-root numeric UID — Kubernetes can verify runAsNonRoot at admission.
 RUN groupadd -g 65532 -r nonroot \
  && useradd -u 65532 -g nonroot -r -s /usr/sbin/nologin -M nonroot
 
 USER 65532:65532
 WORKDIR /application
 
-# copy layers from build image to runtime image as nonroot user
-COPY --from=build --chown=65532:65532 /tmp/target/dependencies/ ./
-COPY --from=build --chown=65532:65532 /tmp/target/snapshot-dependencies/ ./
-COPY --from=build --chown=65532:65532 /tmp/target/spring-boot-loader/ ./
-COPY --from=build --chown=65532:65532 /tmp/target/application/ ./
+# --link decouples these layers from the build-stage digest; rebuilds of
+# the build stage don't invalidate the runtime layers when content is
+# unchanged.
+COPY --link --from=build --chown=65532:65532 /build/target/dependencies/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/snapshot-dependencies/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/spring-boot-loader/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/application/ ./
 
 EXPOSE 8080
-EXPOSE 8081
 
 ENV _JAVA_OPTIONS="-XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 \
 -Djava.security.egd=file:/dev/./urandom \

--- a/Dockerfile.maven-host-m2-cache
+++ b/Dockerfile.maven-host-m2-cache
@@ -1,17 +1,21 @@
+# syntax=docker/dockerfile:1
+
 # renovate: datasource=docker depName=maven
 ARG MAVEN_IMAGE_VERSION=3.9.15-eclipse-temurin-25
 
 # renovate: datasource=docker depName=eclipse-temurin
 ARG TEMURIN_IMAGE_VERSION=25.0.2_10-jre-jammy@sha256:d36843a6f1af5d0aca01ef3d926e2220444eb19fe38e1b23cef3d663ef29b306
 
-# Variant used by scripts/build-dockerimage-m2-cache.sh and the Kaniko script
+# Used by scripts/build-dockerimage-m2-cache.sh and scripts/build-dockerimage-kaniko.sh
 # for local fast iteration — consumes a jar that was pre-built on the host
 # against a shared ~/.m2 volume, so the image build stage only extracts
-# Spring Boot layers. Same runtime base image as the main Dockerfile.
+# Spring Boot layers. Prerequisite: `mvn clean package` must have run on
+# the host first so `target/*.jar` exists.
 FROM maven:${MAVEN_IMAGE_VERSION} AS build
-ADD target target
-WORKDIR target
-RUN java -Djarmode=layertools -jar *.jar extract
+WORKDIR /build
+COPY target target
+WORKDIR /build/target
+RUN java -Djarmode=layertools -jar ./*.jar extract
 
 FROM eclipse-temurin:${TEMURIN_IMAGE_VERSION} AS runtime
 
@@ -21,13 +25,12 @@ RUN groupadd -g 65532 -r nonroot \
 USER 65532:65532
 WORKDIR /application
 
-COPY --from=build --chown=65532:65532 target/dependencies/ ./
-COPY --from=build --chown=65532:65532 target/snapshot-dependencies/ ./
-COPY --from=build --chown=65532:65532 target/spring-boot-loader/ ./
-COPY --from=build --chown=65532:65532 target/application/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/dependencies/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/snapshot-dependencies/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/spring-boot-loader/ ./
+COPY --link --from=build --chown=65532:65532 /build/target/application/ ./
 
 EXPOSE 8080
-EXPOSE 8081
 
 ENV _JAVA_OPTIONS="-XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=90.0 \
 -Djava.security.egd=file:/dev/./urandom \

--- a/README.md
+++ b/README.md
@@ -131,12 +131,13 @@ sequenceDiagram
 
 Image-build variants covered by the repo:
 
-| Path | Entry point | Notes |
-|------|------------|-------|
-| Multi-stage Dockerfile + BuildKit | `Dockerfile` / `scripts/build-dockerimage.sh` | Distroless base image, non-root |
-| Maven + host `~/.m2` cache | `Dockerfile.maven-host-m2-cache` / `scripts/build-dockerimage-m2-cache.sh` | Reuses host Maven cache for faster local iteration |
-| Cloud Native Buildpacks | `scripts/build-dockerimage-buildpacks.sh` | `pack build` via Paketo |
-| Kaniko | `scripts/build-dockerimage-kaniko.sh` | Rootless, CI-friendly |
+| Path | Dockerfile | Entry point | Notes |
+|------|------------|------------|-------|
+| Multi-stage Dockerfile + BuildKit | `Dockerfile` | `scripts/build-dockerimage.sh` / `make image-build` | Eclipse Temurin 25 JRE runtime, non-root UID 65532, BuildKit cache mount on `~/.m2`, `COPY --link` on runtime layers. Canonical path; also used by CI |
+| Maven + host `~/.m2` cache | `Dockerfile.maven-host-m2-cache` | `scripts/build-dockerimage-m2-cache.sh` | Consumes `target/*.jar` pre-built on the host — run `mvn clean package` (or `make build`) first |
+| Cloud Native Buildpacks | — (buildpacks generate the image) | `scripts/build-dockerimage-buildpacks.sh` | `pack build` against pinned `paketobuildpacks/builder-jammy-base` |
+| Kaniko | `Dockerfile.maven-host-m2-cache` | `scripts/build-dockerimage-kaniko.sh` | Rootless, daemonless, CI-friendly. Also consumes host-built `target/*.jar` |
+| Spring Boot Maven plugin `build-image` | — (Paketo via the plugin) | `scripts/build-dockerimage-maven.sh` | `mvn spring-boot:build-image`; image name comes from `<docker.image.name>` in `pom.xml`, `BP_OCI_SOURCE` set so GHCR auto-links to the repo |
 
 ## API
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,8 @@
         <springdoc.version>3.0.3</springdoc.version>
         <!-- Override: Spring Boot 4.0.5 pins Jackson 3.1.0; 3.1.1 fixes GHSA-2m67-wjpj-xhg9 -->
         <jackson-bom.version>3.1.1</jackson-bom.version>
+        <!-- Override: Spring Boot 4.0.5 pins Tomcat 11.0.20; 11.0.21 fixes CVE-2026-34483 + CVE-2026-34487 -->
+        <tomcat.version>11.0.21</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

Triggered by the Dockerfile audit. Three groups of changes in one PR:

**Tomcat CVE fix (release-blocker if merged to a tag)**
- Override `<tomcat.version>11.0.21</tomcat.version>` in pom.xml — SB 4.0.5 pins 11.0.20 which carries CVE-2026-34483 + CVE-2026-34487. Same pattern as the existing Jackson-BOM override. Post-fix: `trivy image --severity CRITICAL,HIGH --ignore-unfixed` reports **0 findings**.

**Dockerfile 2026 best-practices modernisation**
- `# syntax=docker/dockerfile:1` directive (BuildKit features)
- `RUN --mount=type=cache,target=/root/.m2` on mvn invocations — stops re-downloading ~100 MB from Maven Central on every cold build
- `COPY --link` on runtime-stage copies — decouples final layer from build-stage digest
- Consolidated `/build` + `/tmp` dual workspace into one WORKDIR (old dead code)
- Fix hadolint SC2035: `./*.jar` instead of `*.jar`
- Drop redundant `EXPOSE 8081` — application.yml has management on 8080
- Same modernisation applied to `Dockerfile.maven-host-m2-cache`

**`.dockerignore`** (new) — trims BuildKit context so documentation / IDE / CI files don't slow every build and don't invalidate the layer cache on pure-docs changes. Keeps `.git` (needed by git-commit-id-plugin).

**README** — Image-build variants table expanded to 5 rows with a Dockerfile column; notes the `mvn clean package` prerequisite for the m2-cache and Kaniko paths.

## Test plan
- [x] `docker build` succeeds with the new Dockerfile
- [x] `trivy image --severity CRITICAL,HIGH --ignore-unfixed sbd:audit2` → 0 findings
- [x] Container smoke-test: Spring Boot boots in ~2.7s, Tomcat on 8080
- [x] `make lint-docker` passes (hadolint clean)
- [x] `make ci` + `make mermaid-lint` pass
- [ ] GitHub Actions CI green on this branch