### PR TITLE
chore(renovate): add Apache commons grouping + lang:java label rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,19 @@
       "description": "Group springdoc-openapi dependencies",
       "matchPackageNames": ["/^org\\.springdoc/"],
       "groupName": "springdoc-openapi"
+    },
+    {
+      "description": "Group Apache commons dependencies (commons-lang3, commons-collections4, commons-io)",
+      "matchPackageNames": [
+        "commons-io:commons-io",
+        "/^org\\.apache\\.commons:/"
+      ],
+      "groupName": "Apache commons"
+    },
+    {
+      "description": "Label Java packages",
+      "matchCategories": ["java"],
+      "addLabels": ["lang: java"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Two additions from the /renovate review:

- **Apache commons grouping** — `pom.xml` pulls `commons-lang3` + `commons-collections4` (both `org.apache.commons:*`). Without grouping, each gets its own PR. Rule matches `commons-io:commons-io` plus `/^org\.apache\.commons:/`.
- **`lang: java` label rule** — `matchCategories: ["java"]` + `addLabels: ["lang: java"]`. Polishes the default Renovate labelling for polyglot repo searches; no behavioural impact on automerge.

Both rules come directly from the /renovate skill "Java/Maven Projects" template. Validated with `renovate-config-validator`.

## Test plan
- [x] `npx renovate-config-validator renovate.json` passes
- [ ] CI green on this branch