### PR TITLE
chore: bump version to 0.0.1 for initial release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ See `make help` for the full target list.
 
 ## Key Details
 
-- **Group/Artifact**: `com.test:spring-boot-demo:1.0.0`
+- **Group/Artifact**: `com.test:spring-boot-demo:0.0.1`
 - **Java version**: 25 (Temurin LTS, pinned in `.mise.toml` + `.java-version`)
 - **Spring Boot**: 4.0.5 (Spring Framework 7, embedded Tomcat 11)
 - **Default branch**: `main`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.test</groupId>
     <artifactId>spring-boot-demo</artifactId>
-    <version>1.0.0</version>
+    <version>0.0.1</version>
     <packaging>jar</packaging>
     <description>Spring Boot 4 REST APIs demo: Spring Boot, H2, Tomcat, OpenAPI/springdoc, Jackson, Hamcrest, MockMvc
     </description>

--- a/scripts/build-dockerimage-maven.sh
+++ b/scripts/build-dockerimage-maven.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build a container image via `mvn spring-boot:build-image` (Cloud Native
 # Buildpacks under the hood). The image name comes from the pom.xml
-# <docker.image.name> property — defaults to spring-boot-demo:1.0.0.
+# <docker.image.name> property — defaults to spring-boot-demo:0.0.1.
 # Requires Docker to be installed.
 
 set -euo pipefail
@@ -13,6 +13,6 @@ cd "$SCRIPT_DIR/.."
 mvn clean spring-boot:build-image -DskipTests
 
 docker rm -f spring-boot-demo 2>/dev/null || true
-docker run --rm --name spring-boot-demo -p 8080:8080 -p 8181:8081 spring-boot-demo:1.0.0
+docker run --rm --name spring-boot-demo -p 8080:8080 -p 8181:8081 spring-boot-demo:0.0.1
 
 cd "$LAUNCH_DIR"


### PR DESCRIPTION
## Summary
- Bump `pom.xml` version `1.0.0` → `0.0.1` to align with the upcoming `v0.0.1` git tag.
- Update `scripts/build-dockerimage-maven.sh` comment/run tag (`spring-boot-demo:1.0.0` → `:0.0.1`).
- Update `CLAUDE.md` group/artifact reference.

After this merges, tag `v0.0.1` on `main` which will trigger the `docker` job (Trivy scan, multi-arch build, cosign keyless sign, push to `ghcr.io/AndriyKalashnykov/spring-boot-demo/app:0.0.1`). GitHub release created from the tag.

## Why `0.0.1` not `1.0.0`
First tagged release. `0.0.1` reads as "initial pre-1.0 demo" which matches this repo's reference/demo positioning; `1.0.0` would imply API stability that isn't promised. pom sitting at `1.0.0` since the SB2→SB4 migration was template inertia, not a deliberate stability signal.

## Test plan
- [ ] CI green on this PR (test + integration-test + build; `docker` job is skipped on non-tag pushes, which is expected)
- [ ] After merge, tag `v0.0.1` triggers `docker` job → image published and signed
- [ ] `cosign verify ghcr.io/AndriyKalashnykov/spring-boot-demo/app:0.0.1` passes
- [ ] GitHub release `v0.0.1` exists with auto-generated notes