### PR TITLE
docs: release badge + lowercase GHCR refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ GitHub Actions workflows in `.github/workflows/`:
 | CI | `ci.yml` | push to main, PRs, `v*` tags, manual dispatch | Test → Integration-test → Build → Docker (scan + smoke + cosign sign + push) → ci-pass aggregator |
 | Cleanup | `cleanup-runs.yml` | weekly (Sunday) + manual + `workflow_call` | Delete old workflow runs and caches |
 
-No repo-level secrets required — the `docker` job uses `GITHUB_TOKEN` for GHCR auth and Sigstore OIDC for cosign signing. Image is published to `ghcr.io/AndriyKalashnykov/spring-boot-demo/app`.
+No repo-level secrets required — the `docker` job uses `GITHUB_TOKEN` for GHCR auth and Sigstore OIDC for cosign signing. Image is published to `ghcr.io/andriykalashnykov/spring-boot-demo/app` (OCI refs are lowercase).
 
 ## Upgrade Backlog
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Hits](https://hits.sh/github.com/AndriyKalashnykov/spring-boot-demo.svg?view=today-total&style=plastic)](https://hits.sh/github.com/AndriyKalashnykov/spring-boot-demo/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/spring-boot-demo)
+[![GitHub release](https://img.shields.io/github/v/release/AndriyKalashnykov/spring-boot-demo?sort=semver&display_name=tag)](https://github.com/AndriyKalashnykov/spring-boot-demo/releases)
 
 # Spring Boot Container Pipeline Reference
 
@@ -21,7 +22,7 @@ C4Context
     Rel(sbd, registry, "Image pulled from", "docker pull")
 ```
 
-The container registry is [GHCR (GitHub Container Registry)](https://ghcr.io). Published image: `ghcr.io/AndriyKalashnykov/spring-boot-demo/app:<semver>`. Authentication uses `GITHUB_TOKEN` — no separate registry credentials required.
+The container registry is [GHCR (GitHub Container Registry)](https://ghcr.io). Published image: `ghcr.io/andriykalashnykov/spring-boot-demo/app:<semver>` (OCI references are lowercase). Authentication uses `GITHUB_TOKEN` — no separate registry credentials required.
 
 | Component | Technology |
 |-----------|-----------|
@@ -32,7 +33,7 @@ The container registry is [GHCR (GitHub Container Registry)](https://ghcr.io). P
 | Metrics | Spring Boot Actuator + Micrometer Prometheus |
 | Tests | JUnit 5 + Spring MockMvc + TestRestTemplate (via `spring-boot-resttestclient`) |
 | Build | Maven 3.9, multi-stage Dockerfile, Buildpacks, Kaniko, Skaffold |
-| Runtime | Container image on GHCR (`ghcr.io/AndriyKalashnykov/spring-boot-demo/app`); Kubernetes deployment |
+| Runtime | Container image on GHCR (`ghcr.io/andriykalashnykov/spring-boot-demo/app`); Kubernetes deployment |
 | CI | GitHub Actions, Renovate |
 
 ## Quick Start
@@ -345,7 +346,7 @@ Buildkit in-manifest attestations (`provenance`, `sbom`) are disabled so the ima
 Verify a published image's signature:
 
 ```bash
-cosign verify ghcr.io/AndriyKalashnykov/spring-boot-demo/app:<tag> \
+cosign verify ghcr.io/andriykalashnykov/spring-boot-demo/app:<tag> \
   --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/spring-boot-demo/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```


### PR DESCRIPTION
## Summary
- Add a GitHub release badge to the README header (links to `/releases`).
- Lowercase the owner segment in every `ghcr.io/<owner>/spring-boot-demo/app` reference in the README and CLAUDE.md.

## Why the lowercase fix matters
OCI references are case-sensitive and registries reject mixed-case paths. The uppercase-owner examples currently fail to parse when users copy-paste them:

```
$ cosign verify ghcr.io/AndriyKalashnykov/spring-boot-demo/app:0.0.1 ...
Error: parsing reference: could not parse reference: ghcr.io/AndriyKalashnykov/spring-boot-demo/app:0.0.1
```

Same failure mode for `docker pull`. Verified locally that the lowercase form works:

```
$ cosign verify ghcr.io/andriykalashnykov/spring-boot-demo/app:0.0.1 \
    --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/spring-boot-demo/.+' \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com
Verification for ghcr.io/andriykalashnykov/spring-boot-demo/app:0.0.1 --
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```

The `--certificate-identity-regexp` value stays mixed-case because it matches the Fulcio certificate subject (the GitHub repository URL), not an OCI reference.

## Test plan
- [ ] CI green
- [ ] Rendered README shows the release badge reading `v0.0.1`
- [ ] Copy-paste verification block from README and confirm it still verifies against `ghcr.io/andriykalashnykov/spring-boot-demo/app:0.0.1`