### PR TITLE
chore: silence default-enabled warnings + de-duplicate aqua renovate PRs

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -13,19 +13,17 @@ maven = "3.9.15"
 # Static-check + CI tooling installed via mise's aqua backend so a single
 # `mise install` (or `make deps-install`) provides every CLI the Makefile
 # composite gates need. CI inherits the same versions through `jdx/mise-action`.
-# renovate: datasource=github-releases depName=hadolint/hadolint extractVersion=^v(?<version>.*)$
+#
+# No `# renovate:` annotations on the aqua entries below: Renovate's
+# built-in `mise` manager extracts these natively as `aqua:owner/repo`.
+# Adding an annotation creates a duplicate PR per tool because the
+# custom-regex manager would also match on the comment's bare `owner/repo`.
 "aqua:hadolint/hadolint" = "2.14.0"
-# renovate: datasource=github-releases depName=nektos/act extractVersion=^v(?<version>.*)$
 "aqua:nektos/act" = "0.2.87"
-# renovate: datasource=github-releases depName=aquasecurity/trivy extractVersion=^v(?<version>.*)$
 "aqua:aquasecurity/trivy" = "0.70.0"
-# renovate: datasource=github-releases depName=gitleaks/gitleaks extractVersion=^v(?<version>.*)$
 "aqua:gitleaks/gitleaks" = "8.30.1"
-# renovate: datasource=github-releases depName=rhysd/actionlint extractVersion=^v(?<version>.*)$
 "aqua:rhysd/actionlint" = "1.7.12"
-# renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.*)$
 "aqua:koalaman/shellcheck" = "0.11.0"
-# renovate: datasource=github-releases depName=GoogleContainerTools/container-structure-test extractVersion=^v(?<version>.*)$
 "aqua:GoogleContainerTools/container-structure-test" = "1.22.1"
 
 # Tools NOT in mise:

--- a/renovate.json
+++ b/renovate.json
@@ -33,10 +33,10 @@
     },
     {
       "customType": "regex",
-      "description": "Update .mise.toml tool pins via inline renovate comments (supports both bare keys like `java` and quoted keys like `\"aqua:owner/repo\"`)",
+      "description": "Update .mise.toml bare-key tool pins via inline renovate comments. Aqua entries (\"aqua:owner/repo\") are deliberately NOT matched — Renovate's built-in `mise` manager extracts those natively, and matching here would create duplicate PRs per tool.",
       "managerFilePatterns": ["/^\\.mise\\.toml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n(?:[a-zA-Z_-]+|\"[^\"]+\")\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
     },
     {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   jmx:
     enabled: false
+  jpa:
+    # Explicit configuration silences Spring Boot's default-enabled warning.
+    # `true` keeps the existing behaviour (the entity manager stays open through
+    # view rendering); for a high-throughput service this should be `false` to
+    # avoid lazy-loading queries during response rendering.
+    open-in-view: true
 
 server:
   port: 8080
@@ -46,6 +52,15 @@ management:
       enabled: true
     sessions:
       enabled: true
+
+springdoc:
+  # Explicit configuration silences SpringDoc's default-enabled warnings.
+  # The demo intentionally publishes /v3/api-docs and Swagger UI; in production
+  # services these typically flip to `false` so the API surface isn't exposed.
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
 
 info:
   build:


### PR DESCRIPTION
## Summary

Two small post-review cleanups:

- **Silence Spring Boot 4 default-enabled warnings** (`application.yml`): explicitly set `spring.jpa.open-in-view: true` and `springdoc.api-docs/swagger-ui.enabled: true`. These are the values Spring Boot 4 already uses by default, so behavior is unchanged — the explicit config just suppresses the new "default-enabled" startup warnings. Inline comments document the production trade-off (flip both to `false` for high-throughput / private-API services).
- **De-duplicate aqua-tool Renovate PRs** (`renovate.json`, `.mise.toml`): drop `# renovate:` annotations from the `"aqua:owner/repo"` entries in `.mise.toml` and tighten the custom-regex manager to bare keys only. Renovate's built-in `mise` manager already extracts `aqua:` entries natively as `aqua:owner/repo` — keeping the comment-based custom manager active for them produced two PRs per tool bump (the duplicates seen as PR #55, #58, #57 etc.).

## Test plan

- [ ] CI green (static-check, test, integration-test, build, e2e, docker, cve-check)
- [ ] No new "default-enabled" warnings on app startup (verify in `make run` logs)
- [ ] Next renovate run produces only one PR per aqua tool bump (confirm by waiting for the next `aqua:*` update)