### PR TITLE
chore: post-review tidy — Makefile audit, multi-arch image, doc sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,8 @@ jobs:
         with:
           filters: |
             code:
-              - '!**/*.md'
+              - '!(**.md|docs/**|specs/**|img/**|LICENSE|.gitignore|.claudeignore|.claude/**|benchmarks/**|**.png|**.jpg|**.gif|**.svg)'
               - 'CLAUDE.md'
-              - '!docs/**'
-              - '!img/**'
-              - '!LICENSE'
-              - '!.gitignore'
-              - '!.claudeignore'
-              - '!.claude/**'
-              - '!**/*.png'
-              - '!**/*.jpg'
-              - '!**/*.gif'
-              - '!**/*.svg'
 
   # ---------------------------------------------------------------------
   # Composite quality gate: format-check, lint (compile-warning gate),
@@ -258,15 +248,15 @@ jobs:
         run: make cve-check
 
   # ---------------------------------------------------------------------
-  # Tag-gated publish pipeline: pre-push hardening (gates 1-3) followed
-  # by single-arch (linux/amd64) push + cosign keyless signing.
-  #   Gate 1: single-arch build with load: true for scanning/smoke
+  # Tag-gated publish pipeline: pre-push hardening (gates 1-4) followed
+  # by multi-arch (linux/amd64,linux/arm64) push + cosign keyless signing.
+  #   Gate 1: single-arch (amd64) build with load: true for scanning/smoke
   #   Gate 2: Trivy CRITICAL/HIGH blocking (vuln/secret/misconfig)
   #   Gate 3: Spring Boot boot-marker smoke test (no external deps)
   #   Gate 4: container-structure-test (USER, ENTRYPOINT, layout)
-  # On non-tag runs the docker job builds (validating the Dockerfile and
-  # full pipeline) but skips publish/sign — release-day regressions are
-  # caught on every push, not only on tags.
+  # On non-tag runs the docker job builds multi-arch (validating arm64
+  # cross-compile + the full pipeline) but skips publish/sign — release-
+  # day regressions are caught on every push, not only on tags.
   # ---------------------------------------------------------------------
   docker:
     needs: [changes, build, test, integration-test]
@@ -280,6 +270,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
@@ -378,7 +371,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ GitHub Actions workflows in `.github/workflows/`:
 
 | Workflow | File | Triggers | Purpose |
 |----------|------|----------|---------|
-| CI | `ci.yml` | push to main, PRs, `v*` tags, manual dispatch, weekly schedule (`cve-check` only) | changes (paths-filter) → static-check → (test, integration-test, build) → (e2e, docker = scan + smoke + container-structure-test + tag-gated `linux/amd64` push + sign) + cve-check (tags + weekly) → ci-pass aggregator |
+| CI | `ci.yml` | push to main, PRs, `v*` tags, manual dispatch, weekly schedule (`cve-check` only) | changes (paths-filter) → static-check → (test, integration-test, build) → (e2e, docker = scan + smoke + container-structure-test + tag-gated multi-arch `linux/amd64`+`linux/arm64` push + sign) + cve-check (tags + weekly) → ci-pass aggregator |
 | Cleanup old workflow runs | `cleanup-runs.yml` | weekly (Sunday) + manual + `workflow_call` | Delete old workflow runs and orphaned caches (preserves `main`, default branch, tags) |
 
 `NVD_API_KEY` is an optional secret used by the `cve-check` job (free key from NIST NVD; without it OWASP dependency-check still runs but throttled). The `docker` job uses `GITHUB_TOKEN` for GHCR auth and Sigstore OIDC for cosign signing. Image is published to `ghcr.io/andriykalashnykov/spring-boot-demo/app` (OCI refs are lowercase).

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,14 @@ CURRENTTAG  := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 # Java, Maven, hadolint, act, trivy, gitleaks, actionlint, shellcheck,
 # container-structure-test are all pinned in .mise.toml. `make deps-install`
 # (or `mise install`) provisions them from a single source of truth; CI
-# inherits via `jdx/mise-action`. The constants below are the few tools
-# that don't have a mise/aqua entry yet.
+# inherits via `jdx/mise-action`. The constants below are kept in the
+# Makefile because they cannot live in .mise.toml:
+#   - MAVEN_VER: Apache-archives fallback used by `deps-maven` for CI
+#     containers that lack mise (kept in sync with .mise.toml's `maven`).
+#   - GJF_VERSION: google-java-format ships as a JAR, not a binary —
+#     aqua/ubi backends only handle static binaries.
+#   - MERMAID_CLI_VERSION: mermaid-cli runs as a Docker image, not a
+#     local CLI.
 # renovate: datasource=maven depName=org.apache.maven:apache-maven
 MAVEN_VER := 3.9.15
 # renovate: datasource=github-releases depName=google/google-java-format extractVersion=^v(?<version>.*)$
@@ -49,10 +55,24 @@ help:
 	@echo "Commands :"
 	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST) | tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-24s\033[0m - %s\n", $$1, $$2}'
 
-#deps: @ Verify required tools are installed (java, mvn)
+#deps: @ Verify required tools are installed (java, mvn) and provision mise-managed CLIs
 deps:
+	@# Auto-install mise-managed tools (hadolint, act, trivy, gitleaks,
+	@# actionlint, shellcheck, container-structure-test) when mise is
+	@# present locally. CI uses jdx/mise-action so this branch is local-only.
+	@if [ -z "$$CI" ] && command -v mise >/dev/null 2>&1; then \
+		mise install --yes; \
+	fi
 	@command -v java >/dev/null 2>&1 || { echo "Error: Java 25 required. Run: make deps-install"; exit 1; }
 	@command -v $(MVN) >/dev/null 2>&1 || { echo "Error: Maven required. Run: make deps-install"; exit 1; }
+
+#deps-docker: @ Verify Docker is installed (host requirement, not provisioned by mise)
+deps-docker:
+	@command -v docker >/dev/null 2>&1 || { echo "Error: Docker required."; exit 1; }
+
+#deps-node: @ Verify Node.js/npx is available (used by renovate-validate)
+deps-node:
+	@command -v npx >/dev/null 2>&1 || { echo "Error: Node.js/npx required for renovate-validate."; exit 1; }
 
 #deps-install: @ Install Java and Maven via mise (reads .mise.toml)
 deps-install:
@@ -126,20 +146,29 @@ lint: deps
 	@$(MVN) -B compile -Dmaven.compiler.failOnWarning=true -q
 
 #lint-docker: @ Lint the Dockerfile with hadolint (provisioned by mise)
-lint-docker:
+lint-docker: deps
 	@hadolint Dockerfile
 	@hadolint Dockerfile.maven-host-m2-cache
 
 #lint-ci: @ Lint GitHub Actions workflows with actionlint (provisioned by mise; uses shellcheck under the hood)
-lint-ci:
+lint-ci: deps
 	@actionlint .github/workflows/*.yml
 
+#lint-scripts-exec: @ Verify all shell scripts are committed with the executable bit set
+lint-scripts-exec:
+	@NONEXEC=$$(find scripts e2e -name '*.sh' -type f -not -executable 2>/dev/null); \
+	if [ -n "$$NONEXEC" ]; then \
+		echo "Error: shell scripts missing +x (run chmod +x and commit the mode change):"; \
+		echo "$$NONEXEC" | sed 's/^/  /'; \
+		exit 1; \
+	fi
+
 #trivy-fs: @ Scan filesystem for vulnerabilities, secrets, and misconfigurations (provisioned by mise)
-trivy-fs:
+trivy-fs: deps
 	@trivy fs --scanners vuln,secret,misconfig --severity CRITICAL,HIGH .
 
 #secrets: @ Scan working tree for hardcoded secrets with gitleaks (provisioned by mise)
-secrets:
+secrets: deps
 	@gitleaks detect --source . --no-git --verbose --redact
 
 #deps-prune: @ List declared but unused / undeclared but used Maven dependencies
@@ -160,8 +189,7 @@ cve-check: deps
 vulncheck: cve-check
 
 #mermaid-lint: @ Validate Mermaid diagrams in markdown files
-mermaid-lint:
-	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
+mermaid-lint: deps-docker
 	@set -euo pipefail; \
 	IMG="minlag/mermaid-cli:$(MERMAID_CLI_VERSION)"; \
 	if ! docker image inspect "$$IMG" >/dev/null 2>&1; then \
@@ -204,7 +232,7 @@ mermaid-lint:
 #   * `cve-check` CI job — tag pushes + weekly schedule
 # Run `make cve-check` locally before tagging a release.
 #static-check: @ Run all quality and security checks (composite gate)
-static-check: format-check lint lint-docker lint-ci mermaid-lint trivy-fs secrets deps-prune-check
+static-check: format-check lint lint-docker lint-ci lint-scripts-exec mermaid-lint trivy-fs secrets deps-prune-check
 	@echo "Static check passed."
 
 #integration-test: @ Run integration tests (*IT.java via Failsafe)
@@ -216,11 +244,11 @@ e2e: build
 	@./e2e/smoke.sh
 
 #image-build: @ Build Docker image (multi-stage)
-image-build: build
+image-build: build deps-docker
 	@docker buildx build --load -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 
 #image-test: @ Validate image structure (USER, ENTRYPOINT, layout) via container-structure-test
-image-test: image-build
+image-test: image-build deps
 	@container-structure-test test \
 		--image $(DOCKER_IMAGE):$(DOCKER_TAG) \
 		--config container-structure-test.yaml
@@ -230,7 +258,7 @@ image-run: image-build image-stop
 	@docker run --rm -d -p 8080:8080 --name $(APP_NAME) $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 #image-stop: @ Stop Docker container
-image-stop:
+image-stop: deps-docker
 	@docker stop $(APP_NAME) 2>/dev/null || true
 
 #image-push: @ Push Docker image to registry
@@ -238,25 +266,35 @@ image-push: image-build
 	@docker push $(DOCKER_REGISTRY)/$(DOCKER_REPO):$(DOCKER_TAG)
 
 #ci: @ Full local CI pipeline
-ci: deps format-check lint test integration-test build
+ci: deps static-check test integration-test build
 	@echo "Local CI pipeline passed."
 
 #ci-run: @ Run GitHub Actions workflows locally via act (per-job, fail-fast; act provisioned by mise)
-ci-run:
+ci-run: deps deps-docker
 	@docker container prune -f 2>/dev/null || true
-	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
+	@# act's synthetic push-event payload omits `repository.default_branch`,
+	@# which dorny/paths-filter falls back to when computing the diff base.
+	@# Generate a minimal payload via --eventpath; without this, the
+	@# `changes` job fails with "This action requires 'base' input or
+	@# 'repository.default_branch' to be set in the event payload".
+	@evt=$$(mktemp /tmp/act-push-event.XXXXXX.json); \
+	printf '{"ref":"refs/heads/main","repository":{"default_branch":"main","name":"$(APP_NAME)","full_name":"AndriyKalashnykov/$(APP_NAME)"}}' >"$$evt"; \
+	ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
 	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
+	rc=0; \
 	for job in static-check test integration-test build e2e; do \
 		echo "=== act --job $$job ==="; \
 		act push --container-architecture linux/amd64 \
 			--artifact-server-port "$$ACT_PORT" \
 			--artifact-server-path "$$ARTIFACT_PATH" \
-			--job "$$job" || exit $$?; \
-	done
+			--eventpath "$$evt" \
+			--job "$$job" || { rc=$$?; break; }; \
+	done; \
+	rm -f "$$evt"; \
+	exit $$rc
 
 #renovate-validate: @ Validate renovate.json configuration
-renovate-validate:
-	@command -v npx >/dev/null 2>&1 || { echo "Error: node/npx required for renovate validation"; exit 1; }
+renovate-validate: deps-node
 	@npx --yes --package renovate -- renovate-config-validator renovate.json
 
 #release: @ Create and push a new tag (interactive)
@@ -268,7 +306,7 @@ release:
 		git push origin $$newtag && \
 		echo "Done."'
 
-.PHONY: help deps deps-install deps-maven deps-check deps-prune deps-prune-check \
-	clean build test run format format-check lint lint-docker lint-ci mermaid-lint trivy-fs secrets \
+.PHONY: help deps deps-install deps-maven deps-check deps-docker deps-node deps-prune deps-prune-check \
+	clean build test run format format-check lint lint-docker lint-ci lint-scripts-exec mermaid-lint trivy-fs secrets \
 	cve-check vulncheck static-check integration-test e2e image-build image-test image-run image-stop image-push \
 	ci ci-run renovate-validate release

--- a/README.md
+++ b/README.md
@@ -269,8 +269,11 @@ Run `make help` to see the full list.
 | Target | Description |
 |--------|-------------|
 | `make help` | List available tasks |
-| `make deps` | Verify required tools are installed (java, mvn) |
+| `make deps` | Verify required tools and provision mise-managed CLIs |
 | `make deps-install` | Install Java + Maven via mise (reads `.mise.toml`) |
+| `make deps-maven` | Install Maven from Apache archives (CI-container fallback) |
+| `make deps-docker` | Verify Docker is installed |
+| `make deps-node` | Verify Node.js/npx is available (used by `renovate-validate`) |
 | `make deps-check` | Show installation status of every required tool |
 
 ### Build & Run
@@ -298,13 +301,14 @@ Run `make help` to see the full list.
 | `make lint` | Compiler warnings-as-errors + Checkstyle (`google_checks.xml`, `severity=error`) |
 | `make lint-docker` | Lint both Dockerfiles with `hadolint` |
 | `make lint-ci` | Lint GitHub Actions workflows with `actionlint` |
+| `make lint-scripts-exec` | Verify all `scripts/*.sh` and `e2e/*.sh` are committed with the executable bit set |
 | `make mermaid-lint` | Validate Mermaid blocks with pinned `minlag/mermaid-cli` |
 | `make trivy-fs` | Scan filesystem for CVEs, secrets, misconfigurations |
 | `make secrets` | Scan repo for leaked secrets with `gitleaks` |
 | `make cve-check` | OWASP dependency-check vulnerability scan |
 | `make deps-prune` | Show declared-but-unused / used-undeclared Maven dependencies |
 | `make deps-prune-check` | Fail on any used-undeclared or unused-declared dependency (manual; not in CI — Spring Boot starters create false positives) |
-| `make static-check` | Composite gate: format-check, lint, lint-docker, lint-ci, mermaid-lint, trivy-fs, secrets |
+| `make static-check` | Composite gate: format-check, lint, lint-docker, lint-ci, lint-scripts-exec, mermaid-lint, trivy-fs, secrets, deps-prune-check |
 
 ### Docker
 
@@ -320,7 +324,7 @@ Run `make help` to see the full list.
 
 | Target | Description |
 |--------|-------------|
-| `make ci` | Full local CI pipeline (format-check + lint + test + build) |
+| `make ci` | Full local CI pipeline (`static-check` composite gate + test + integration-test + build) |
 | `make ci-run` | Run GitHub Actions workflows locally via [act](https://github.com/nektos/act) |
 | `make renovate-validate` | Validate `renovate.json` |
 
@@ -337,13 +341,13 @@ GitHub Actions runs on push to `main`, pull requests, `v*` tags, manual dispatch
 | Job | Triggers | Purpose |
 |-----|----------|---------|
 | `changes` | all | Path filter — gates heavy jobs on code/build/CI changes |
-| `static-check` | code diffs | `make static-check` — format-check, lint (Checkstyle), lint-docker, lint-ci, mermaid-lint, trivy-fs, secrets |
+| `static-check` | code diffs | `make static-check` — format-check, lint (Checkstyle), lint-docker, lint-ci, lint-scripts-exec, mermaid-lint, trivy-fs, secrets, deps-prune-check |
 | `test` | code diffs | `make test` — JUnit via Spring MockMvc |
 | `integration-test` | code diffs | `make integration-test` — `*IT.java` via Maven Failsafe |
 | `build` | code diffs | `make build` — packages the jar, uploads as artifact |
 | `e2e` | code diffs | `make e2e` — boots the packaged JAR on a free port, curl-based CRUD + Actuator + Swagger smoke |
 | `cve-check` | tags + weekly + dispatch | OWASP dependency-check; NVD database cached |
-| `docker` | code diffs (build always; push/sign tag-gated at step level) | Build, Trivy scan, smoke-test, container-structure-test, `linux/amd64` push (tag only), cosign sign (tag only) |
+| `docker` | code diffs (build always; push/sign tag-gated at step level) | Build, Trivy scan, smoke-test, container-structure-test, multi-arch (`linux/amd64`+`linux/arm64`) push (tag only), cosign sign (tag only) |
 | `ci-pass` | all | Aggregator gate for branch protection |
 
 A separate `Cleanup old workflow runs` workflow prunes old workflow runs and orphaned caches on a weekly schedule (Sunday 00:00 UTC) plus manual dispatch.
@@ -360,7 +364,7 @@ The `docker` job runs these gates **before** any image is pushed to GHCR. Any fa
 | 2 | Trivy image scan (CRITICAL/HIGH blocking) | Fixed CVEs in base image, OS packages, build layers | `aquasecurity/trivy-action` with `image-ref:` |
 | 3 | Spring Boot boot-marker smoke test | Image fails to start (classpath, JVM flags, config) | `docker run` + grep boot marker in logs |
 | 4 | container-structure-test | USER/ENTRYPOINT/WORKDIR/exposed-port drift, layered-jar layout regressions | `container-structure-test` against `container-structure-test.yaml` |
-| 5 | Build + push | Publishes `linux/amd64` to GHCR | `docker/build-push-action` with `push: true` |
+| 5 | Build + push | Publishes multi-arch (`linux/amd64`+`linux/arm64`) to GHCR | `docker/build-push-action` with `push: true` |
 | 6 | Cosign keyless OIDC signing | Sigstore signature on the manifest digest | `sigstore/cosign-installer` + `cosign sign` |
 
 Buildkit in-manifest attestations (`provenance`, `sbom`) are disabled so the image index stays free of `unknown/unknown` platform entries — this keeps the registry "OS / Arch" tab rendering correctly. Cosign keyless signing provides supply-chain verification.


### PR DESCRIPTION
## Summary

Bundle of three reviews (Makefile, CI workflow, README/CLAUDE.md) and one ci-run regression fix.

### Makefile (`/makefile` audit)

- `ci` target now runs the full `static-check` composite gate (was just `format-check + lint`)
- New `lint-scripts-exec` target — catches shell scripts committed without `+x` (caught by `make ci`/`static-check`, not just by CI exit-126)
- New `deps-docker` and `deps-node` targets — extracted from inline `command -v` checks in `mermaid-lint` and `renovate-validate`
- Wire `deps` (or `deps-docker`) as a prerequisite onto `lint-docker`, `lint-ci`, `trivy-fs`, `secrets`, `mermaid-lint`, and the `image-*` targets so a fresh checkout works without separate `mise install`
- `deps` now runs `mise install --yes` automatically when run locally (CI provisions tools via `jdx/mise-action`, so the bootstrap branch is `[ -z "$$CI" ]`-gated)
- Reword the stale "constants below don't have a mise/aqua entry yet" comment to explain each constant's actual purpose (CI fallback / JAR / Docker image)

### CI workflow (`/ci-workflow` audit)

- **Multi-arch publish**: `linux/amd64,linux/arm64` (was amd64 only). Added `docker/setup-qemu-action` before buildx setup
- Normalized the `changes`-detector filter to the canonical negated-alternation form (`'!(**.md|docs/**|specs/**|...)'` + `'CLAUDE.md'`). Added `specs/**` and `benchmarks/**` to the canonical exclude list

### `ci-run` fix

`make ci-run` was failing on the `changes` job because act's synthetic push-event payload omits `repository.default_branch`, which `dorny/paths-filter` falls back to when computing the diff base. Fix: generate a minimal payload via `--eventpath` (the canonical pattern from the `/makefile` skill).

### Docs (`/readme` + `/claude`)

- README hardening gate 5 + CI/CD job table updated to reflect multi-arch
- README Make Targets tables: added `deps-docker`, `deps-node`, `deps-maven`, `lint-scripts-exec`; updated `static-check` composition; updated `make ci` description
- CLAUDE.md CI workflow description updated for multi-arch

## Test plan

- [x] `make static-check` passes locally
- [x] `make ci` passes locally
- [x] `make ci-run` passes locally (all 5 act jobs: static-check, test, integration-test, build, e2e — the `--eventpath` fix verified)
- [ ] CI green on this PR (static-check, test, integration-test, build, e2e, docker)
- [ ] `docker` job's multi-arch build step succeeds (validates arm64 cross-compile on every push under Pattern A)