### PR TITLE
fix: bump Tomcat to 11.0.22 for 6 newly-disclosed CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,9 @@
         <springdoc.version>3.0.3</springdoc.version>
         <!-- Override: Spring Boot 4.0.5 pins Jackson 3.1.0; 3.1.1 fixes GHSA-2m67-wjpj-xhg9 -->
         <jackson-bom.version>3.1.1</jackson-bom.version>
-        <!-- Override: Spring Boot 4.0.5 pins Tomcat 11.0.20; 11.0.21 fixes CVE-2026-34483 + CVE-2026-34487 -->
-        <tomcat.version>11.0.21</tomcat.version>
+        <!-- Override: bump Tomcat ahead of the Spring Boot 4.0.6 BOM; 11.0.22 fixes
+             CVE-2026-41293/43512/43515 (CRITICAL) + CVE-2026-41284/42498/43513 (HIGH) -->
+        <tomcat.version>11.0.22</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

The Trivy image scan in the `docker` job started failing — on `main` and on **every open PR** (#84, #85, #86) — because six new CVEs were disclosed against `org.apache.tomcat.embed:tomcat-embed-core` **11.0.21** (the version pinned in `pom.xml`):

| CVE | Severity |
|-----|----------|
| CVE-2026-41293, CVE-2026-43512, CVE-2026-43515 | CRITICAL |
| CVE-2026-41284, CVE-2026-42498, CVE-2026-43513 | HIGH |

All six are fixed in **11.0.22**. This bumps the `tomcat.version` override (which already exists to lead the Spring Boot BOM) from `11.0.21` → `11.0.22`.

The code on `main` is unchanged — the prior green run predates the CVE disclosure; a fresh scan of unchanged code now fails. This is exactly what the weekly `cve-check` schedule guards against, surfacing here via the per-PR `docker` job.

## Test plan

Verified locally by reproducing the exact failing gate:

- `mvn dependency:tree` → `tomcat-embed-core`, `-el`, `-websocket` all resolve to `11.0.22`
- `make build` + `make test` → BUILD SUCCESS, 2/2 tests pass
- `make image-build` then `trivy image --severity CRITICAL,HIGH --ignore-unfixed --pkg-types os,library --scanners vuln,secret,misconfig --exit-code 1` → **exit 0** (was exit 1)

Once merged, PRs #84 / #85 / #86 will be rebased onto the fixed `main` and go green.