### PR TITLE
chore: apply project-review fixes across infra + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # On a tag push, force code=true so the publish path runs even when the
+      # tagged SHA is already on main (paths-filter would otherwise compute an
+      # empty diff → code=false → docker job skips → silent no-op release).
+      code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -53,14 +56,16 @@ jobs:
   # ---------------------------------------------------------------------
   static-check:
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -70,22 +75,24 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Static check
         run: make static-check
 
   test:
     needs: [changes, static-check]
-    if: needs.changes.outputs.code == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -95,22 +102,24 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Test
         run: make test
 
   integration-test:
     needs: [changes, static-check]
-    if: needs.changes.outputs.code == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -120,8 +129,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Integration test
         run: make integration-test
@@ -137,14 +146,16 @@ jobs:
 
   build:
     needs: [changes, static-check]
-    if: needs.changes.outputs.code == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -154,8 +165,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Build
         run: make build
@@ -177,14 +188,16 @@ jobs:
   # ---------------------------------------------------------------------
   e2e:
     needs: [changes, build]
-    if: needs.changes.outputs.code == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -194,10 +207,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
-      - name: E2E smoke
+      - name: E2E
         run: make e2e
 
       - name: Upload e2e log
@@ -222,7 +235,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up toolchain (mise)
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
@@ -232,8 +245,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
-          key: maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Cache NVD database
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -260,7 +273,9 @@ jobs:
   # ---------------------------------------------------------------------
   docker:
     needs: [changes, build, test, integration-test]
-    if: needs.changes.outputs.code == 'true'
+    if: |
+      !failure() && !cancelled() &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -342,8 +357,9 @@ jobs:
 
       # GATE 4: container-structure-test — validates USER, ENTRYPOINT,
       # WORKDIR, exposed ports, layered-jar layout. Catches Dockerfile
-      # drift that compiles but breaks runtime contracts.
-      - name: Set up toolchain (mise — for container-structure-test)
+      # drift that compiles but breaks runtime contracts. mise here
+      # provides the container-structure-test binary.
+      - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   cleanup-runs:
-    name: Delete old workflow runs
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -34,7 +33,6 @@ jobs:
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
 
   cleanup-caches:
-    name: Delete caches whose source branch no longer exists
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ See `make help` for the full target list.
 ## Project Structure
 
 - `src/main/java/com/test/example/` -- Application source (Spring Boot REST)
-- `src/test/java/` -- Tests (MockMvc)
+- `src/main/fabric8/` -- Kubernetes manifests (`dc.yml` / `pod.yml` / `svc.yml`)
+- `src/test/java/` -- Tests: `.../test/` (MockMvc unit), `.../it/` (`*IT.java` Failsafe integration)
 - `pom.xml` -- Maven build config (Spring Boot 4.0.6, Java 25)
 - `Dockerfile` / `Dockerfile.maven-host-m2-cache` -- Multi-stage Docker builds
 - `container-structure-test.yaml` -- USER/ENTRYPOINT/layered-jar layout assertions (run via `make image-test`)
@@ -33,7 +34,7 @@ See `make help` for the full target list.
 - `scripts/` -- Docker image build scripts (multi-stage, Buildpacks, Kaniko, Spring Boot layered jar, m2-cache) + local run helpers
 - `LICENSE` -- MIT
 - `skaffold.yaml` -- Skaffold config (Paketo buildpacks)
-- `hotel.json` -- Sample API payload
+- `scripts/hotel.json` / `scripts/hotel.xml` -- Sample API payloads (JSON + XML)
 - `Makefile` -- Build orchestration
 - `.mise.toml` -- Pinned Java/Maven versions
 - `renovate.json` -- Dependency update configuration
@@ -69,7 +70,7 @@ Two pre-Spring-Boot-4 commits introduced secrets that were later removed from th
 | `bededf26e6cddae9d3baf6b56ecd989831dd233d:config.json:generic-api-key:1` | 2020-08-22 | `config.json` (removed) | generic-api-key |
 | `d0585218c825162913ba1c895a901143eeb32ff6:plain.cfg:private-key:19` | 2020-09-24 | `plain.cfg` (removed) | private-key |
 
-## Upgrade Backlog
+## Migration History
 
 ### Done — Spring Boot 4 migration (2026-04-22)
 
@@ -109,6 +110,15 @@ Resolved by the SB 2.3.9 → 4.0.5 migration:
 - Dependabot alert #21 verified fixed (along with 13 other historical alerts; 0 open now)
 - ci.yml aligned to `/ci-workflow` canon: `jdx/mise-action` + explicit Maven cache, `contains(needs.*.result, 'failure')` aggregator, `paths-ignore` trigger filter, `workflow_call` trigger, canonical step names on every `uses:` step
 - `renovate.json`: Apache commons grouping + `lang: java` label rule added; Jackson rule covers both `com.fasterxml.jackson` and `tools.jackson` namespaces; 7-day throttle on `java-version` datasource for mise-aqua race
+
+### Also resolved (2026-05-22 — project-review pass)
+
+- Tomcat `11.0.21` → `11.0.22` override — 6 newly-disclosed CVEs (CVE-2026-41293/43512/43515 CRITICAL, CVE-2026-41284/42498/43513 HIGH); rebuilt image scans 0 CRITICAL/HIGH
+- `cve-check` no longer passes the NVD key on the `mvn` command line — routed through a transient `settings.xml` + `-DnvdApiServerId` (no `ps`/`/proc` argv leak)
+- `pom.xml` `maven-compiler-plugin` now sets `failOnWarning` so every `mvn` build (not only `make lint`) treats compiler warnings as errors
+- `ci.yml`: tag pushes force `changes.code=true` (closes the empty-diff silent-no-op-release trap); heavy-job `if:` clauses gained the `!failure() && !cancelled()` guard; Maven cache keys gained a `runner.os` prefix
+- `renovate.json`: `skaffold.yaml` buildpacks builder now Renovate-tracked; Makefile customManager regex covers `?=` / `registryUrl`; Maven distribution grouped across `mise` + `Makefile`; `pinDigests` disabled for Makefile docker pins
+- `scripts/build-dockerimage-kaniko.sh`: docker-auth `config.json` written `0600` and removed on any exit
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,18 @@ deps-prune-check: deps
 
 #cve-check: @ Run OWASP dependency vulnerability scan (CVSS >= 7 blocks; matches the Trivy image scan threshold)
 cve-check: deps
-	@$(MVN) -B org.owasp:dependency-check-maven:check \
-		$$([ -n "$$NVD_API_KEY" ] && echo "-DnvdApiKey=$$NVD_API_KEY") \
-		-DfailBuildOnCVSS=7
+	@# NVD_API_KEY must never reach mvn's argv (visible via ps -ef / /proc/<pid>/cmdline).
+	@# Route it through a transient settings.xml (printf is a bash builtin — no argv leak;
+	@# umask 077 keeps the file 0600) referenced by -DnvdApiServerId; the temp file is
+	@# removed on any exit. Without a key, dependency-check still runs (throttled).
+	@if [ -n "$$NVD_API_KEY" ]; then \
+		SETTINGS="$$(mktemp)"; \
+		trap 'rm -f "$$SETTINGS"' EXIT; \
+		( umask 077 && printf '<settings><servers><server><id>nvd</id><password>%s</password></server></servers></settings>\n' "$$NVD_API_KEY" > "$$SETTINGS" ); \
+		$(MVN) -B -s "$$SETTINGS" org.owasp:dependency-check-maven:check -DnvdApiServerId=nvd -DfailBuildOnCVSS=7; \
+	else \
+		$(MVN) -B org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=7; \
+	fi
 
 #vulncheck: @ Alias for cve-check
 vulncheck: cve-check

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Spring Boot Container Pipeline Reference
 
-A small Spring Boot REST microservice (hotel CRUD over an in-memory H2) used as a reference for four container image build paths — multi-stage Dockerfile with BuildKit (consuming Spring Boot's layered jar), Cloud Native Buildpacks via the `pack` CLI, Kaniko, and the Spring Boot Maven plugin's `build-image` goal (Paketo). Ships with a hardened GitHub Actions pipeline (Trivy image scan, boot-marker smoke test, multi-arch build, cosign keyless signing to GHCR) and a Skaffold-driven Kubernetes deployment flow. The application is deliberately minimal — the value is in the image, CI, and deployment harness around it.
+A deliberately minimal Spring Boot 4 REST microservice (hotel CRUD over in-memory H2) that serves as a **hardened container-pipeline reference** — the value is the build, test, and delivery harness around the app, not the app itself. **Build:** four image paths — multi-stage Dockerfile with BuildKit (consuming Spring Boot's layered jar), Cloud Native Buildpacks via the `pack` CLI, Kaniko, and the Spring Boot Maven plugin's `build-image` goal (Paketo). **Test:** a three-layer pyramid — Spring MockMvc unit tests, `*IT.java` Failsafe integration tests, and a packaged-JAR e2e smoke test. **Delivery:** a GitHub Actions pipeline with a `static-check` composite gate (`google-java-format`, Checkstyle, hadolint, actionlint, `gitleaks`, Mermaid lint, Trivy filesystem scan), a Trivy image scan, a boot-marker smoke test, `container-structure-test`, multi-arch build, and cosign keyless signing to GHCR — plus OWASP dependency-check, a mise-pinned toolchain, Renovate dependency automation, and a Skaffold-driven Kubernetes deploy.
 
 ```mermaid
 C4Context
@@ -19,7 +19,7 @@ C4Context
 
     Rel(client, sbd, "CRUD /example/v1/hotels", "HTTPS / JSON")
     Rel(prom, sbd, "Metrics scrape", "HTTP")
-    Rel(sbd, registry, "Image pulled from", "docker pull")
+    Rel(sbd, registry, "Published as a signed image to", "OCI / cosign-signed")
 ```
 
 The container registry is [GHCR (GitHub Container Registry)](https://ghcr.io). Published image: `ghcr.io/andriykalashnykov/spring-boot-demo/app:<semver>` (OCI references are lowercase). Authentication uses `GITHUB_TOKEN` — no separate registry credentials required.
@@ -40,7 +40,7 @@ The container registry is [GHCR (GitHub Container Registry)](https://ghcr.io). P
 
 ```bash
 make deps-install   # install Java 25 + Maven via mise (first run only)
-make test           # run unit tests
+make build          # compile and package the jar
 make run            # start the application on http://localhost:8080
 # Open http://localhost:8080/swagger-ui/index.html
 ```
@@ -52,7 +52,7 @@ make run            # start the application on http://localhost:8080
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Git](https://git-scm.com/) | 2.0+ | Source control |
 | [JDK](https://adoptium.net/) | 25 (Temurin LTS) | Java runtime and compiler |
-| [Maven](https://maven.apache.org/) | 3.9+ | Build and dependency management |
+| [Maven](https://maven.apache.org/) | 3.9.16 | Build and dependency management |
 | [Docker](https://www.docker.com/) | 20.10+ | Image build and local container runs |
 | [mise](https://mise.jdx.dev/) | latest | Java/Maven version management |
 | [curl](https://curl.se/) | any | HTTP client for smoke testing |
@@ -97,6 +97,7 @@ C4Container
 - **H2 Database** — in-memory JPA/Hibernate datastore; data is transient and resets on each application restart (intentional for the demo).
 - **Prometheus** — scrapes `/actuator/prometheus` over HTTP; no push gateway, no remote write.
 - **GHCR** — receives signed multi-arch images from GitHub Actions; consumers verify with `cosign verify` against the workflow's OIDC identity.
+- **GitHub Actions** — CI/CD: runs the three-layer test pyramid, builds and Trivy-scans the image, signs it with cosign, and publishes the multi-arch image to GHCR on tag pushes.
 
 ### Request flow
 
@@ -306,6 +307,7 @@ Run `make help` to see the full list.
 | `make trivy-fs` | Scan filesystem for CVEs, secrets, misconfigurations |
 | `make secrets` | Scan repo for leaked secrets with `gitleaks` |
 | `make cve-check` | OWASP dependency-check vulnerability scan |
+| `make vulncheck` | Alias for `make cve-check` |
 | `make deps-prune` | Show declared-but-unused / used-undeclared Maven dependencies |
 | `make deps-prune-check` | Fail on any used-undeclared or unused-declared dependency (manual; not in CI — Spring Boot starters create false positives) |
 | `make static-check` | Composite gate: format-check, lint, lint-docker, lint-ci, lint-scripts-exec, mermaid-lint, trivy-fs, secrets, deps-prune-check |

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,17 @@
 
         <plugins>
             <plugin>
+                <!-- Treat compiler warnings as errors for every `mvn` invocation
+                     (build, test, run, IDE), not only `make lint`. Version is
+                     managed by the Spring Boot parent. -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <failOnWarning>true</failOnWarning>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>

--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,7 @@
       "description": "Update Makefile tool versions via inline renovate comments",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*:=\\s*(?<currentValue>[^\\s]+)"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?(?: registryUrl=(?<registryUrl>[^\\s]+))?\\n[A-Z_]+\\s*[?:]?=\\s*(?<currentValue>[^\\s]+)"
       ]
     },
     {
@@ -36,7 +36,7 @@
       "description": "Update .mise.toml bare-key tool pins via inline renovate comments. Aqua entries (\"aqua:owner/repo\") are deliberately NOT matched — Renovate's built-in `mise` manager extracts those natively, and matching here would create duplicate PRs per tool.",
       "managerFilePatterns": ["/^\\.mise\\.toml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
     },
     {
@@ -44,7 +44,15 @@
       "description": "Update scripts/*.sh image pins via inline renovate comments (shell VAR=\"value\" assignments)",
       "managerFilePatterns": ["/^scripts/.+\\.sh$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( extractVersion=(?<extractVersion>[^\\s]+))?( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+=\"(?<currentValue>[^\"]+)\""
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+=\"(?<currentValue>[^\"]+)\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update the skaffold.yaml buildpacks builder image via inline renovate comment",
+      "managerFilePatterns": ["/^skaffold\\.yaml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n\\s*builder:\\s*\"[^\"]+:(?<currentValue>[^\"]+)\""
       ]
     }
   ],
@@ -105,6 +113,19 @@
       "description": "Label Java packages",
       "matchCategories": ["java"],
       "addLabels": ["lang: java"]
+    },
+    {
+      "description": "Group the Maven distribution across mise (.mise.toml) and the Makefile MAVEN_VER pin so both bump in one PR (they share datasource=maven / depName=org.apache.maven:apache-maven and would otherwise collide in Renovate dedup)",
+      "matchManagers": ["mise", "custom.regex"],
+      "matchPackageNames": ["org.apache.maven:apache-maven"],
+      "groupName": "Maven"
+    },
+    {
+      "description": "Disable digest pinning for Makefile-tracked Docker tags — config:best-practices enables docker:pinDigests, which collides on the same renovate branch with the version bump for digest-less Makefile pins (e.g. MERMAID_CLI_VERSION)",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["Makefile"],
+      "matchDatasources": ["docker"],
+      "pinDigests": false
     }
   ]
 }

--- a/scripts/build-app-host-m2-cache.sh
+++ b/scripts/build-app-host-m2-cache.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # renovate: datasource=docker depName=maven
-MAVEN_IMAGE_TAG="3-eclipse-temurin-25"
+MAVEN_IMAGE_TAG="3.9.16-eclipse-temurin-25"
 
 LAUNCH_DIR=$(pwd); SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; cd $SCRIPT_DIR; cd ..; SCRIPT_PARENT_DIR=$(pwd);
 cd $SCRIPT_PARENT_DIR

--- a/scripts/build-dockerimage-kaniko.sh
+++ b/scripts/build-dockerimage-kaniko.sh
@@ -10,15 +10,15 @@ cd $SCRIPT_PARENT_DIR
 echo $(pwd)
 
 REGISTRY_URL="https://index.docker.io/v1/"
-AUTH=$(echo -n $DOCKER_LOGIN:$DOCKER_PWD | base64)
-# echo "{\"auths\":{\"$REGISTRY_URL\":{\"auth\":\"$AUTH\"}}}" > config.json
-echo "{\"auths\":{\"$REGISTRY_URL\":{\"username\":\"$DOCKER_LOGIN\",\"password\":\"$DOCKER_PWD\"}}}" > config.json
-# cat config.json
+AUTH=$(printf '%s' "$DOCKER_LOGIN:$DOCKER_PWD" | base64)
+# Write the kaniko docker-auth config with restrictive perms (0600) and remove
+# it on any exit — registry credentials must not linger world-readable on disk.
+( umask 077 && printf '{"auths":{"%s":{"auth":"%s"}}}\n' "$REGISTRY_URL" "$AUTH" > config.json )
+trap 'rm -f config.json' EXIT
 
 docker image rm -f $DOCKER_LOGIN/spring-boot-demo:latest
 # -v ~/.docker/config.json:/kaniko/.docker/config.json:ro
 time docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro --env DOCKER_CONFIG=/kaniko/.docker "${KANIKO_IMAGE}" --verbosity INFO --cache=true --cache-ttl=168h --cache-repo $DOCKER_LOGIN/spring-boot-demo-cache --dockerfile Dockerfile.maven-host-m2-cache --context dir:///workspace/ --destination $DOCKER_LOGIN/spring-boot-demo
-rm config.json
 #time docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro --env DOCKER_CONFIG=/kaniko/.docker "${KANIKO_IMAGE}" --verbosity DEBUG --dockerfile Dockerfile.maven-host-m2-cache --context dir:///workspace/ --no-push
 #docker run -m500M --name spring-boot-demo -p 8080:8080 -p 8181:8081 -p 8778:8778 spring-boot-demo:latest
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,7 +7,8 @@ build:
   artifacts:
     - image: spring-boot-demo
       buildpacks:
-        builder: "gcr.io/paketo-buildpacks/builder:base"
+        # renovate: datasource=docker depName=paketobuildpacks/builder-jammy-base
+        builder: "paketobuildpacks/builder-jammy-base:0.4.576"
 
 #        builder: "gcr.io/buildpacks/builder:v1"
 #        env:


### PR DESCRIPTION
## Summary

Applies the fixes surfaced by a full `/project-review` pass — 8 parallel skill-driven reviews of the Makefile, CI workflows, Renovate config, README, CLAUDE.md, the Docker image pipeline, test coverage, and architecture diagrams. **38 findings** were reported (9 HIGH, 13 MEDIUM, 16 LOW); every actionable one is applied here. Docker-hardening and test-coverage findings are research-only (they need `/harden-image-pipeline` and `/test-coverage-analysis`) and are **not** in this PR.

## Foundation changes

| Area | Fix |
|------|-----|
| **Makefile** | `cve-check` no longer passes `NVD_API_KEY` on the `mvn` command line (HIGH — argv leaks via `ps`/`/proc`); routed through a transient `settings.xml` (`printf` + `umask 077`) + `-DnvdApiServerId` |
| **pom.xml** | `maven-compiler-plugin` `failOnWarning` — every `mvn` build treats compiler warnings as errors, not only `make lint` |
| **ci.yml** | Tag pushes force `changes.code=true` (closes the empty-diff silent-no-op-release trap); heavy-job `if:` clauses gained `!failure() && !cancelled()`; Maven cache keys gained a `runner.os` prefix; step names normalised |
| **cleanup-runs.yml** | Dropped job-level `name:` overrides for canonical-template parity |
| **renovate.json** | `skaffold.yaml` builder now Renovate-tracked; Makefile customManager regex covers `?=`/`registryUrl` + non-capturing groups; Maven distribution grouped across `mise`+`Makefile`; `pinDigests` off for Makefile docker pins |
| **scripts** | `build-app-host-m2-cache.sh` Maven tag pinned to a Renovate-resolvable version; `build-dockerimage-kaniko.sh` auth `config.json` written `0600` + removed on exit |

## Documentation changes

- **README**: description rewritten with bolded build/test/delivery surface anchors; `make vulncheck` row added; Quick Start uses `make build`; Maven prerequisite pinned to `3.9.16`; Container-view caption documents the GitHub Actions element; Context-diagram GHCR relationship direction corrected.
- **CLAUDE.md**: "Upgrade Backlog" → "Migration History"; `hotel.json` path corrected; `src/main/fabric8/` and the `it/` test package documented; a `2026-05-22` history entry appended.
- **Repo metadata** (via GitHub API, outside the diff): About description re-aligned to the H1 title; stale topics `mongodb` + `docker-compose` removed.

## Not applied (deliberate)

- **Test-coverage** findings (k8s e2e gap + the stale `fabric8` probe path/port, edge-case tests) — research-only; run `/test-coverage-analysis`.
- **Docker-hardening** — pipeline is already hardened; only an optional DAST job / CODEOWNERS remain (run `/harden-image-pipeline`).
- **Mermaid C4 legend** (arch LOW) — Mermaid C4 has no clean legend directive; not cleanly actionable.
- **skaffold.yaml `apiVersion: skaffold/v2beta8`** is stale, but a schema bump needs a real skaffold run to verify — left for a dedicated change.

## Test plan

- `make ci` → BUILD SUCCESS (static-check + test + integration-test + build)
- `make ci-run` (act) → all jobs pass, e2e 12/12; cache key confirmed as `maven-Linux-…`
- `make renovate-validate` → config validated successfully
- `make mermaid-lint` → all blocks render
- `actionlint` → clean