### PR TITLE
chore: project-review remediation (Makefile, CI, Renovate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,12 @@ jobs:
   # ---------------------------------------------------------------------
   # OWASP dependency-check. Runs on tag pushes, weekly schedule, and
   # manual dispatch — too slow for every push (NVD download dominates).
-  # NVD database cached keyed on pom.xml.
+  # The NVD database is independent of project deps, so it is cached keyed
+  # on the ISO week (not pom.xml — a pom bump would needlessly evict the DB
+  # → cold ~30-min refetch that then throttles under anonymous limits).
+  # Two vuln sources run: NVD (NVD_API_KEY) and Sonatype OSS Index
+  # (OSS_INDEX_USER + OSS_INDEX_TOKEN — OSS Index is silently disabled
+  # without them; see the Makefile cve-check recipe).
   # ---------------------------------------------------------------------
   cve-check:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -248,16 +253,22 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: maven-${{ runner.os }}-
 
+      - name: Compute NVD cache week
+        id: nvdweek
+        run: echo "week=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache NVD database
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository/org/owasp/dependency-check-data
-          key: nvd-${{ hashFiles('**/pom.xml') }}
+          key: nvd-${{ steps.nvdweek.outputs.week }}
           restore-keys: nvd-
 
       - name: CVE check
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          OSS_INDEX_USER: ${{ secrets.OSS_INDEX_USER }}
+          OSS_INDEX_TOKEN: ${{ secrets.OSS_INDEX_TOKEN }}
         run: make cve-check
 
   # ---------------------------------------------------------------------
@@ -430,6 +441,10 @@ jobs:
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "One or more jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs were cancelled"
             exit 1
           fi
           echo "All required jobs passed or were skipped."

--- a/.mise.toml
+++ b/.mise.toml
@@ -5,9 +5,13 @@
 # few days — so newer Renovate PRs (e.g. 25.0.3+9) may fail `mise install`
 # until aqua re-scrapes. Revert to the latest known-good patch when that
 # happens.
-# renovate: datasource=java-version depName=java
+#
+# NOTE: no `# renovate:` annotations on these bare keys — Renovate's native
+# `mise` manager extracts java/maven directly. A custom.regex over .mise.toml
+# (removed 2026-06-05) double-tracked them under different packageNames and
+# produced duplicate PRs; the 7-day java buffer + Maven grouping now key off
+# the native mise depNames (`java-jdk`, `apache/maven`) in renovate.json.
 java = "temurin-25.0.3+9.0.LTS"
-# renovate: datasource=maven depName=org.apache.maven:apache-maven
 maven = "3.9.16"
 
 # Static-check + CI tooling installed via mise's aqua backend so a single

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ See `make help` for the full target list.
 - `Makefile` -- Build orchestration
 - `.mise.toml` -- Pinned Java/Maven versions
 - `renovate.json` -- Dependency update configuration
+- `img/` -- README image assets (IntelliJ remote-run screenshot)
 
 ## Key Details
 
@@ -58,7 +59,11 @@ GitHub Actions workflows in `.github/workflows/`:
 | CI | `ci.yml` | push to main, PRs, `v*` tags, manual dispatch, weekly schedule (`cve-check` only) | changes (paths-filter) → static-check → (test, integration-test, build) → (e2e, docker = scan + smoke + container-structure-test + tag-gated multi-arch `linux/amd64`+`linux/arm64` push + sign) + cve-check (tags + weekly) → ci-pass aggregator |
 | Cleanup old workflow runs | `cleanup-runs.yml` | weekly (Sunday) + manual + `workflow_call` | Delete old workflow runs and orphaned caches (preserves `main`, default branch, tags) |
 
-`NVD_API_KEY` is an optional secret used by the `cve-check` job (free key from NIST NVD; without it OWASP dependency-check still runs but throttled). The `docker` job uses `GITHUB_TOKEN` for GHCR auth and Sigstore OIDC for cosign signing. Image is published to `ghcr.io/andriykalashnykov/spring-boot-demo/app` (OCI refs are lowercase).
+The `cve-check` job runs OWASP dependency-check against two independent vuln sources, each gated on optional secrets:
+- `NVD_API_KEY` (free key from NIST NVD; without it the NVD analyzer still runs but throttled).
+- `OSS_INDEX_USER` + `OSS_INDEX_TOKEN` (free token from https://ossindex.sonatype.org/) — the Sonatype OSS Index analyzer now mandates token auth and is **silently disabled** (warning only, exit 0) without them, so a green `cve-check` without these runs at reduced coverage. Both tokens are routed through a transient `0600` `settings.xml` (never on mvn's argv) referenced by `-DnvdApiServerId`/`-DossIndexServerId`.
+
+The `docker` job uses `GITHUB_TOKEN` for GHCR auth and Sigstore OIDC for cosign signing. Image is published to `ghcr.io/andriykalashnykov/spring-boot-demo/app` (OCI refs are lowercase).
 
 ### Historical secret leaks (rotated; informational)
 

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,22 @@ export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
 MVN := mvn
 
 # Docker image config
+# DOCKER_REGISTRY is `:=` (not `?=`) so an ambient exported env var cannot
+# silently redirect `make image-push` to the wrong registry; a deliberate
+# `make DOCKER_REGISTRY=docker.io image-push` CLI override still works.
+# DOCKER_REPO is the GHCR owner/repo namespace (OCI refs are lowercase). Note
+# CI publishes+signs the `.../spring-boot-demo/app` package (extra `/app`
+# segment, set in ci.yml's docker metadata `images:`); this local push target
+# uses the shorter owner/repo form.
 DOCKER_IMAGE    := $(APP_NAME)
-DOCKER_REGISTRY ?= docker.io
-DOCKER_REPO     ?= $(APP_NAME)
+DOCKER_REGISTRY := ghcr.io
+DOCKER_REPO     ?= andriykalashnykov/spring-boot-demo
 DOCKER_TAG      ?= $(APP_VERSION)
+
+# Local image-run port mapping (host:container). Tunable via env; defaults
+# mirror the app's bind port (8080).
+HOST_PORT          ?= 8080
+APP_INTERNAL_PORT  ?= 8080
 
 # google-java-format JAR (cached once)
 GJF_JAR := $(HOME)/.cache/google-java-format/google-java-format-$(GJF_VERSION)-all-deps.jar
@@ -117,7 +129,7 @@ test: deps
 
 #run: @ Start the application locally
 run: deps
-	@$(MVN) -B spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=default" -DskipTests
+	@$(MVN) -B org.springframework.boot:spring-boot-maven-plugin:run -Dspring-boot.run.arguments="--spring.profiles.active=default" -DskipTests
 
 #format: @ Auto-format Java source code (Google style)
 format: $(GJF_JAR)
@@ -142,7 +154,7 @@ format-check: $(GJF_JAR)
 #lint: @ Compiler warnings-as-errors + Checkstyle (google_checks.xml, severity=error)
 lint: deps
 	@$(MVN) -B validate
-	@$(MVN) -B checkstyle:check
+	@$(MVN) -B org.apache.maven.plugins:maven-checkstyle-plugin:check
 	@$(MVN) -B compile -Dmaven.compiler.failOnWarning=true -q
 
 #lint-docker: @ Lint the Dockerfile with hadolint (provisioned by mise)
@@ -173,26 +185,41 @@ secrets: deps
 
 #deps-prune: @ List declared but unused / undeclared but used Maven dependencies
 deps-prune: deps
-	@$(MVN) -B dependency:analyze
+	@$(MVN) -B org.apache.maven.plugins:maven-dependency-plugin:analyze
 
 #deps-prune-check: @ Fail the build on any used-undeclared or unused-declared Maven dependency
 deps-prune-check: deps
-	@$(MVN) -B dependency:analyze -DfailOnWarning=true
+	@$(MVN) -B org.apache.maven.plugins:maven-dependency-plugin:analyze -DfailOnWarning=true
 
 #cve-check: @ Run OWASP dependency vulnerability scan (CVSS >= 7 blocks; matches the Trivy image scan threshold)
 cve-check: deps
-	@# NVD_API_KEY must never reach mvn's argv (visible via ps -ef / /proc/<pid>/cmdline).
-	@# Route it through a transient settings.xml (printf is a bash builtin — no argv leak;
-	@# umask 077 keeps the file 0600) referenced by -DnvdApiServerId; the temp file is
-	@# removed on any exit. Without a key, dependency-check still runs (throttled).
-	@if [ -n "$$NVD_API_KEY" ]; then \
-		SETTINGS="$$(mktemp)"; \
-		trap 'rm -f "$$SETTINGS"' EXIT; \
-		( umask 077 && printf '<settings><servers><server><id>nvd</id><password>%s</password></server></servers></settings>\n' "$$NVD_API_KEY" > "$$SETTINGS" ); \
-		$(MVN) -B -s "$$SETTINGS" org.owasp:dependency-check-maven:check -DnvdApiServerId=nvd -DfailBuildOnCVSS=7; \
-	else \
-		$(MVN) -B org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=7; \
-	fi
+	@# Secrets (NVD_API_KEY, OSS_INDEX_TOKEN) must never reach mvn's argv
+	@# (visible via ps -ef / /proc/<pid>/cmdline). Route them through a
+	@# transient settings.xml (printf is a bash builtin — no argv leak;
+	@# umask 077 keeps the file 0600) referenced by -DnvdApiServerId /
+	@# -DossIndexServerId; the temp file is removed on any exit.
+	@#
+	@# OWASP dependency-check runs TWO independent vuln sources: NVD and
+	@# Sonatype OSS Index. OSS Index now mandates token auth — without
+	@# OSS_INDEX_USER + OSS_INDEX_TOKEN it is SILENTLY disabled (warning
+	@# only, exit 0) and CVE coverage is reduced. Free token:
+	@# https://ossindex.sonatype.org/. Without either credential the scan
+	@# still runs (NVD throttled, OSS Index off).
+	@set -euo pipefail; \
+	SETTINGS="$$(mktemp)"; \
+	trap 'rm -f "$$SETTINGS"' EXIT; \
+	SERVERS=""; \
+	FLAGS="-DfailBuildOnCVSS=7"; \
+	if [ -n "$${NVD_API_KEY:-}" ]; then \
+		SERVERS="$$SERVERS<server><id>nvd</id><password>$$NVD_API_KEY</password></server>"; \
+		FLAGS="$$FLAGS -DnvdApiServerId=nvd"; \
+	fi; \
+	if [ -n "$${OSS_INDEX_USER:-}" ] && [ -n "$${OSS_INDEX_TOKEN:-}" ]; then \
+		SERVERS="$$SERVERS<server><id>ossindex</id><username>$$OSS_INDEX_USER</username><password>$$OSS_INDEX_TOKEN</password></server>"; \
+		FLAGS="$$FLAGS -DossIndexServerId=ossindex"; \
+	fi; \
+	( umask 077 && printf '<settings><servers>%s</servers></settings>\n' "$$SERVERS" > "$$SETTINGS" ); \
+	$(MVN) -B -s "$$SETTINGS" org.owasp:dependency-check-maven:check $$FLAGS
 
 #vulncheck: @ Alias for cve-check
 vulncheck: cve-check
@@ -240,8 +267,25 @@ mermaid-lint: deps-docker
 #   * Trivy image scan (CRITICAL/HIGH) in the docker job — every push
 #   * `cve-check` CI job — tag pushes + weekly schedule
 # Run `make cve-check` locally before tagging a release.
+#check-maven-alignment: @ Verify the Maven version is identical across .mise.toml, Makefile, and both Dockerfiles
+check-maven-alignment:
+	@set -euo pipefail; \
+	mise_ver=$$(sed -n 's/^maven = "\(.*\)"/\1/p' .mise.toml); \
+	df_ver=$$(sed -n 's/^ARG MAVEN_IMAGE_VERSION=\([0-9.]*\)-.*/\1/p' Dockerfile); \
+	dfm_ver=$$(sed -n 's/^ARG MAVEN_IMAGE_VERSION=\([0-9.]*\)-.*/\1/p' Dockerfile.maven-host-m2-cache); \
+	fail=0; \
+	for pair in ".mise.toml=$$mise_ver" "Dockerfile=$$df_ver" "Dockerfile.maven-host-m2-cache=$$dfm_ver"; do \
+		f=$${pair%%=*}; v=$${pair#*=}; \
+		if [ "$$v" != "$(MAVEN_VER)" ]; then \
+			echo "Maven version drift: $$f has '$$v' but Makefile MAVEN_VER is '$(MAVEN_VER)'"; \
+			fail=1; \
+		fi; \
+	done; \
+	if [ "$$fail" -ne 0 ]; then exit 1; fi; \
+	echo "Maven version aligned ($(MAVEN_VER)) across .mise.toml, Makefile, and both Dockerfiles."
+
 #static-check: @ Run all quality and security checks (composite gate)
-static-check: format-check lint lint-docker lint-ci lint-scripts-exec mermaid-lint trivy-fs secrets deps-prune-check
+static-check: check-maven-alignment format-check lint lint-docker lint-ci lint-scripts-exec mermaid-lint trivy-fs secrets deps-prune-check
 	@echo "Static check passed."
 
 #integration-test: @ Run integration tests (*IT.java via Failsafe)
@@ -264,7 +308,7 @@ image-test: image-build deps
 
 #image-run: @ Run Docker container
 image-run: image-build image-stop
-	@docker run --rm -d -p 8080:8080 --name $(APP_NAME) $(DOCKER_IMAGE):$(DOCKER_TAG)
+	@docker run --rm -d -p $(HOST_PORT):$(APP_INTERNAL_PORT) --name $(APP_NAME) $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 #image-stop: @ Stop Docker container
 image-stop: deps-docker
@@ -280,6 +324,11 @@ ci: deps static-check test integration-test build
 
 #ci-run: @ Run GitHub Actions workflows locally via act (per-job, fail-fast; act provisioned by mise)
 ci-run: deps deps-docker
+	@# The loop below runs static-check/test/integration-test/build/e2e.
+	@# `docker` and `cve-check` are intentionally omitted: `docker` needs
+	@# multi-arch buildx + QEMU + GHCR push (heavy DinD, not meaningful under
+	@# act — validate locally via `make image-test` / `make image-build`);
+	@# `cve-check` runs the slow OWASP NVD download (tag/scheduled only).
 	@docker container prune -f 2>/dev/null || true
 	@# act's synthetic push-event payload omits `repository.default_branch`,
 	@# which dorny/paths-filter falls back to when computing the diff base.
@@ -317,5 +366,6 @@ release:
 
 .PHONY: help deps deps-install deps-maven deps-check deps-docker deps-node deps-prune deps-prune-check \
 	clean build test run format format-check lint lint-docker lint-ci lint-scripts-exec mermaid-lint trivy-fs secrets \
+	check-maven-alignment \
 	cve-check vulncheck static-check integration-test e2e image-build image-test image-run image-stop image-push \
 	ci ci-run renovate-validate release

--- a/e2e/smoke.sh
+++ b/e2e/smoke.sh
@@ -114,6 +114,12 @@ if [[ -n "${LOCATION}" ]]; then
   ID="${LOCATION##*/}"
   assert_status        GET    "${BASE}/example/v1/hotels/${ID}" 200
   assert_body_contains "${BASE}/example/v1/hotels/${ID}"        'E2E Hotel'
+  # PUT update — body id MUST match the path id; a mismatch returns 400 via
+  # DataFormatException. Exercises the update path against the real server
+  # (integration covers it in-process, but not through the packaged JAR).
+  UPDATED_PAYLOAD="{\"id\":${ID},\"name\":\"E2E Hotel Updated\",\"description\":\"smoke test\",\"city\":\"Tucson\",\"rating\":5}"
+  assert_status        PUT    "${BASE}/example/v1/hotels/${ID}" 204 "${UPDATED_PAYLOAD}"
+  assert_body_contains "${BASE}/example/v1/hotels/${ID}"        'E2E Hotel Updated'
   assert_status        DELETE "${BASE}/example/v1/hotels/${ID}" 204
   assert_status        GET    "${BASE}/example/v1/hotels/${ID}" 404
 else
@@ -126,6 +132,33 @@ assert_status GET "${BASE}/example/v1/hotels?page=0&size=10" 200
 
 # Negative case (numeric path bound to Long; use a high ID that won't exist)
 assert_status GET "${BASE}/example/v1/hotels/9999999" 404
+
+# XML content negotiation round-trip. json+xml is a real produces/consumes
+# contract on every Hotel endpoint (Spring Boot 4 swapped XStream for Jackson
+# XML); integration covers it in-process, this proves it through the packaged
+# JAR. Root element is <hotel> per @XmlRootElement(name = "hotel").
+XML_PAYLOAD='<hotel><name>E2E XML Hotel</name><description>xml smoke</description><city>Mesa</city><rating>4</rating></hotel>'
+XML_LOCATION=$(curl -sfi -X POST "${BASE}/example/v1/hotels" \
+  -H 'Content-Type: application/xml' \
+  -H 'Accept: application/xml' \
+  -d "${XML_PAYLOAD}" | tr -d '\r' | grep -i '^Location:' | awk '{print $2}' || true)
+
+if [[ -n "${XML_LOCATION}" ]]; then
+  echo "PASS: POST (xml) /example/v1/hotels -> 201 Location=${XML_LOCATION}"
+  PASS=$((PASS + 1))
+  XML_BODY=$(curl -sf -H 'Accept: application/xml' "${XML_LOCATION}" || true)
+  if echo "${XML_BODY}" | grep -q '<name>E2E XML Hotel</name>'; then
+    echo "PASS: GET (xml) ${XML_LOCATION} contains <name>E2E XML Hotel</name>"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: GET (xml) ${XML_LOCATION} missing <name> element (body: ${XML_BODY:0:200})"
+    FAIL=$((FAIL + 1))
+  fi
+  curl -sf -o /dev/null -X DELETE "${XML_LOCATION}" || true
+else
+  echo "FAIL: POST (xml) /example/v1/hotels did not return a Location header"
+  FAIL=$((FAIL + 1))
+fi
 
 # Build/commit metadata endpoint
 assert_status GET "${BASE}/commitid" 200

--- a/renovate.json
+++ b/renovate.json
@@ -33,14 +33,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update .mise.toml bare-key tool pins via inline renovate comments. Aqua entries (\"aqua:owner/repo\") are deliberately NOT matched — Renovate's built-in `mise` manager extracts those natively, and matching here would create duplicate PRs per tool.",
-      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: extractVersion=(?<extractVersion>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n[a-zA-Z_-]+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ]
-    },
-    {
-      "customType": "regex",
       "description": "Update scripts/*.sh image pins via inline renovate comments (shell VAR=\"value\" assignments)",
       "managerFilePatterns": ["/^scripts/.+\\.sh$/"],
       "matchStrings": [
@@ -73,9 +65,9 @@
       "groupName": "GitHub Actions"
     },
     {
-      "description": "Delay Temurin java-version bumps for 7 days so mise's aqua backend indexes the new patch before Renovate proposes it (Adoptium announces same-day; aqua re-scrapes with a few-day lag)",
+      "description": "Delay Temurin java-version bumps for 7 days so mise's aqua backend indexes the new patch before Renovate proposes it (Adoptium announces same-day; aqua re-scrapes with a few-day lag). The native `mise` manager surfaces the .mise.toml java pin as packageName `java-jdk`; `java` is retained for forward-compat.",
       "matchDatasources": ["java-version"],
-      "matchPackageNames": ["java"],
+      "matchPackageNames": ["java", "java-jdk"],
       "minimumReleaseAge": "7 days"
     },
     {
@@ -115,9 +107,9 @@
       "addLabels": ["lang: java"]
     },
     {
-      "description": "Group the Maven distribution across mise (.mise.toml) and the Makefile MAVEN_VER pin so both bump in one PR (they share datasource=maven / depName=org.apache.maven:apache-maven and would otherwise collide in Renovate dedup)",
+      "description": "Group the Maven distribution across the native mise manager (.mise.toml, packageName apache/maven via github-releases) and the Makefile MAVEN_VER custom.regex pin (packageName org.apache.maven:apache-maven via maven) so both bump in one PR. The two sides use different datasources, so both packageNames must be listed explicitly.",
       "matchManagers": ["mise", "custom.regex"],
-      "matchPackageNames": ["org.apache.maven:apache-maven"],
+      "matchPackageNames": ["org.apache.maven:apache-maven", "apache/maven"],
       "groupName": "Maven"
     },
     {

--- a/src/test/java/com/test/example/it/CommitInfoIT.java
+++ b/src/test/java/com/test/example/it/CommitInfoIT.java
@@ -49,4 +49,25 @@ class CommitInfoIT {
     assertTrue(first.containsKey("branch"), "commit object must have 'branch' field");
     assertTrue(first.containsKey("time"), "commit object must have 'time' field");
   }
+
+  @Test
+  void getCommitIdReturnsXml() {
+    // /commitid declares produces = {application/json, application/xml}; this
+    // exercises the XML representation, which the JSON test above does not.
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_XML));
+    ResponseEntity<String> response =
+        restTemplate.exchange("/commitid", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertTrue(
+        response.getHeaders().getContentType().includes(MediaType.APPLICATION_XML),
+        "response must honor the XML Accept header");
+    String body = response.getBody();
+    assertNotNull(body, "XML body must be present");
+    // Commit fields default to "" when git.properties is absent, so the element
+    // tags are present regardless of whether .git metadata was packaged.
+    assertTrue(body.contains("<id"), "XML must include the serialised <id> element");
+    assertTrue(body.contains("<branch"), "XML must include the serialised <branch> element");
+  }
 }

--- a/src/test/java/com/test/example/it/ErrorEnvelopeIT.java
+++ b/src/test/java/com/test/example/it/ErrorEnvelopeIT.java
@@ -94,6 +94,55 @@ class ErrorEnvelopeIT {
     assertNotNull(body.get("message"), "message must be present");
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void constraintViolationReturnsRestErrorInfoEnvelope() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    // size=0 violates @Min(1) on the size param (method-level @Validated) →
+    // ConstraintViolationException → handleConstraintViolation → 400. The
+    // existing HotelControllerIT asserts the status only; this pins the body.
+    ResponseEntity<Map> response =
+        restTemplate.exchange(
+            HOTELS_PATH + "?page=0&size=0", HttpMethod.GET, new HttpEntity<>(headers), Map.class);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    Map<String, Object> body = response.getBody();
+    assertNotNull(body, "400 response must have a body");
+    assertEquals(
+        "handleConstraintViolation",
+        body.get("detail"),
+        "detail must identify the ConstraintViolationException handler");
+    assertNotNull(body.get("message"), "message must be present");
+  }
+
+  @Test
+  void notFoundReturnsXmlRestErrorInfoEnvelope() {
+    // RestErrorInfo is @XmlRootElement-annotated; the error envelope must honor
+    // an XML Accept header just like the success responses do.
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_XML));
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            HOTELS_PATH + "/" + Long.MAX_VALUE,
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            String.class);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    assertTrue(
+        response.getHeaders().getContentType().includes(MediaType.APPLICATION_XML),
+        "error response must honor the XML Accept header");
+    String body = response.getBody();
+    assertNotNull(body, "404 XML response must have a body");
+    assertTrue(
+        body.contains("handleResourceNotFoundException"),
+        "XML envelope must carry the handler detail");
+    assertTrue(body.contains("<detail"), "XML envelope must serialise the <detail> element");
+  }
+
   private URI createHotel(String prefix) {
     Hotel h = new Hotel();
     h.setName(prefix + "-name");


### PR DESCRIPTION
Remediation from a `/project-review` pass. All findings validated locally (`make help`, `make check-maven-alignment`, actionlint, renovate schema, cve-check shell-parse — all green).

## HIGH
- **Maven plugin goals fully-qualified** (`spring-boot:run`/`checkstyle:check`/`dependency:analyze` → `groupId:artifactId:goal`) so a transient Central prefix-metadata 403 can't fail a cached build.
- **OSS Index wired into `cve-check`** — OWASP dependency-check now runs both NVD and Sonatype OSS Index (OSS Index is silently disabled without token auth). Both tokens routed through a transient `0600` settings.xml, never on mvn argv.
- **NVD DB cache keyed on ISO week** (`date -u +%Y-%V`) instead of pom hash — a pom bump no longer evicts the vuln DB into a cold ~30-min refetch.
- **Renovate `.mise.toml` custom manager removed** — it double-tracked `java`/`maven` against the native `mise` manager under divergent packageNames, producing duplicate PRs.

## MEDIUM
- New `check-maven-alignment` target (first prereq of `static-check`) fails on Maven version drift across `.mise.toml`/Makefile/both Dockerfiles.
- `ci-pass` now fails on `cancelled` jobs, not only `failure`.
- Maven group + java-version delay rules re-pointed to native-mise depNames (`apache/maven`, `java-jdk`).

## LOW
- `DOCKER_REGISTRY := ghcr.io` (`:=` prevents ambient-env redirect); `DOCKER_REPO ?= andriykalashnykov/spring-boot-demo`; `image-run` port env-driven.
- `ci-run` docker/cve-check omissions documented; `img/` documented in CLAUDE.md.

## Declined (rationale)
- CI "changes filter omits `specs/**`" — false positive (filter already has `specs/**|img/**`).
- CI "`base:` on paths-filter" — N/A, `ci-run` doesn't invoke the `changes` job under act.
- CI "cleanup-runs inline cache pruning" — functional superset of canonical; no change.
- Renovate "`renovate-validate` → `--platform=local`" — would turn a fast offline schema gate into a network+token-requiring full dry-run.

## Action required after merge
Provision repo secrets `OSS_INDEX_USER` + `OSS_INDEX_TOKEN` (free at https://ossindex.sonatype.org/) for the OSS Index analyzer to run — inert-but-harmless until then.

## Out of scope (research-only in project-review)
Docker pipeline (already fully hardened) and 4 LOW test-coverage gaps — being run separately via `/harden-image-pipeline` and `/test-coverage-analysis`.