### PR TITLE
chore: migrate git-commit-id plugin to maintained coordinate (10.0.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,9 +291,9 @@
             </plugin>
 
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.9.10</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>10.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>


### PR DESCRIPTION
`/ship-it` Stage 1 (upgrade analysis) finding: the git-commit-id plugin was on the **legacy coordinate** `pl.project13.maven:git-commit-id-plugin:4.9.10` (~2021), renamed to `io.github.git-commit-id:git-commit-id-maven-plugin` at 5.x. The groupId/artifactId change is invisible to Renovate's maven manager, so it sat 6 majors behind.

## Change
- `pl.project13.maven:git-commit-id-plugin:4.9.10` → `io.github.git-commit-id:git-commit-id-maven-plugin:10.0.0` (pom-only, 3 lines).

## Compatibility verified
- Config carries over unchanged: `useNativeGit`, `generateGitPropertiesFile`, `generateGitPropertiesFilename`, `commitIdGenerationMode=full`, `dateFormat`; goals `revision` + `validateRevision`.
- `git.properties` keys consumed by `CommitInfoController` (`git.commit.id.full`, `git.branch`, `git.commit.message.full`, `git.commit.time`) are byte-identical in the new output.
- 10.x requires Java 11+/Maven 3.6.3+ — project has Java 25 / Maven 3.9.16.
- Renovate's maven manager now auto-tracks the new coordinate (no `renovate.json` change needed).

## Validation
- `make integration-test` → **32/32** (`CommitInfoIT` 2/2 incl. the new XML test)
- `make e2e` → **16/16** (`/commitid` 200)