### PR TITLE
chore: 3-day stability buffer for mise aqua-tool bumps (prevent tag-before-publish 404)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,12 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "Hold mise aqua-tool bumps (github-tags datasource: hadolint, act, trivy, gitleaks, actionlint, shellcheck, container-structure-test) for a 3-day stability buffer. mise's aqua: backend installs the binary from the upstream GitHub *Release*, but Renovate's native mise manager proposes off the *tag* (github-tags datasource) — so a tag pushed before its release artifacts publish yields a PR that 404s on `mise install` and reddens static-check. The major-only (3d) and java-version (7d) rules above don't cover aqua patch/minor bumps. Source: PR #113 — trivy 0.71.0->0.71.1 was tagged 2026-06-10 with no GitHub Release published, so mise/aqua 404'd. See /renovate skill 'mise aqua: backend can race ahead of upstream release artifacts'.",
+      "matchManagers": ["mise"],
+      "matchDatasources": ["github-tags"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "description": "Group Spring Boot dependencies",
       "matchPackageNames": ["/^org\\.springframework\\.boot/"],
       "groupName": "Spring Boot"


### PR DESCRIPTION
## Why

Follow-up hardening from the PR-backlog cleanup. PR #113 (trivy `0.71.0`→`0.71.1`) was un-mergeable because trivy pushed the `v0.71.1` git tag (2026-06-10) but **never published the GitHub Release** — mise's `aqua:` backend installs the binary from the Release, while Renovate's native `mise` manager proposes off the *tag* (`github-tags` datasource). So `mise install` 404'd and `static-check` failed.

This is a known, documented class (`/renovate` skill: *"mise aqua: backend can race ahead of upstream release artifacts"*). The prescribed durable fix is a `minimumReleaseAge` buffer on the mise manager — which this repo was **missing** (it only had `major`-scoped 3d and `java-version`-scoped 7d buffers; neither covers an aqua **patch** bump).

## Change

One packageRule:
```json
{ "matchManagers": ["mise"], "matchDatasources": ["github-tags"], "minimumReleaseAge": "3 days" }
```

Scoping by the `github-tags` datasource targets exactly the aqua tools (hadolint, act, trivy, gitleaks, actionlint, shellcheck, container-structure-test) without touching the deliberate `java-version` 7-day rule or the Maven `github-releases` grouping. Validated with `renovate-config-validator` (✓). This prevents the next aqua tool from opening a doomed PR during its tag→Release publish window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)