### PR TITLE
chore: fix recurring Renovate pin-digest failure + bump trivy 0.71.1

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -24,7 +24,7 @@ maven = "3.9.16"
 # custom-regex manager would also match on the comment's bare `owner/repo`.
 "aqua:hadolint/hadolint" = "2.14.0"
 "aqua:nektos/act" = "0.2.89"
-"aqua:aquasecurity/trivy" = "0.71.0"
+"aqua:aquasecurity/trivy" = "0.71.1"
 "aqua:gitleaks/gitleaks" = "8.30.1"
 "aqua:rhysd/actionlint" = "1.7.12"
 "aqua:koalaman/shellcheck" = "0.11.0"

--- a/renovate.json
+++ b/renovate.json
@@ -119,10 +119,15 @@
       "groupName": "Maven"
     },
     {
-      "description": "Disable digest pinning for Makefile-tracked Docker tags — config:best-practices enables docker:pinDigests, which collides on the same renovate branch with the version bump for digest-less Makefile pins (e.g. MERMAID_CLI_VERSION)",
+      "description": "Disable digest pinning for ALL custom.regex-tracked Docker tags (Makefile MERMAID_CLI_VERSION, scripts/*.sh maven/kaniko/paketo pins, skaffold.yaml builder). config:best-practices enables docker:pinDigests, but the custom-regex matchStrings capture only currentValue (no currentDigest group / no FROM-line @sha256 slot), so Renovate cannot write a digest into a `VAR=\"image:tag\"` assignment and the pin fails every run ('Error updating branch: update failure' on the Dependency Dashboard). The production Dockerfile is digest-pinned via the dockerfile manager; these auxiliary build helpers stay version-pinned. Previously scoped to Makefile only; broadened after the scripts/skaffold pins kept erroring (issue #39).",
       "matchManagers": ["custom.regex"],
-      "matchFileNames": ["Makefile"],
       "matchDatasources": ["docker"],
+      "pinDigests": false
+    },
+    {
+      "description": "Disable digest pinning for the BuildKit frontend syntax directive (# syntax=docker/dockerfile:1). config:best-practices' docker:pinDigests tries to pin it, which fails the same way; docker/dockerfile:1 is the recommended floating tag for the frontend.",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["docker/dockerfile"],
       "pinDigests": false
     }
   ]


### PR DESCRIPTION
Resolves the actionable problems surfaced on the Renovate **Dependency Dashboard** (#39).

## Finding 1 — recurring `Error updating branch: update failure`
`config:best-practices` enables `docker:pinDigests`, which Renovate tried to apply to docker-datasource deps tracked by the custom.regex managers (`scripts/*.sh` maven/kaniko/paketo pins, `skaffold.yaml` builder) and the `# syntax=docker/dockerfile:1` directive. Those refs are plain `VAR="image:tag"` / syntax-directive forms with **no digest slot**, so the pin can never be written and the branch update fails every run.

The existing `pinDigests:false` opt-out was scoped to **Makefile only**. This:
- broadens it to **all** custom.regex docker deps, and
- adds an opt-out for the `dockerfile` manager's `docker/dockerfile` frontend directive (`:1` is the recommended floating tag).

The production `Dockerfile` remains fully `@sha256`-digest-pinned via the dockerfile manager (built/scanned/signed in CI) — only the auxiliary build helpers stay version-pinned, consistent with the established posture.

## Finding 2 — trivy `0.71.0 → 0.71.1`
PR #113 was correctly closed on 2026-06-13 because the `v0.71.1` tag had no GitHub release (mise/aqua 404'd). The release is now published (2026-06-15, 47 assets) and installs cleanly via `mise install aqua:aquasecurity/trivy@0.71.1` (verified: `Version: 0.71.1`).

## Validation
- `renovate-config-validator renovate.json` → validated successfully
- `jq empty renovate.json` → valid JSON
- trivy 0.71.1 installs + runs via mise/aqua
- diff scoped to `.mise.toml` + `renovate.json` only